### PR TITLE
Fix the lost `}` in i2c.md

### DIFF
--- a/src/markdown-pages/docs/api/i2c.md
+++ b/src/markdown-pages/docs/api/i2c.md
@@ -45,7 +45,7 @@ const i2c0 = new I2C(0);
 i2c0.close();
 
 // open bus 1 in master mode, full speed
-const i2c1 = new I2C(1, {mode: I2C.MASTER, baudrate: 400000);
+const i2c1 = new I2C(1, { mode: I2C.MASTER, baudrate: 400000 });
 // read or write ...
 i2c1.close();
 ```


### PR DESCRIPTION
just a little change