### PR TITLE
Remove orphan parentheses from getting-started.md

### DIFF
--- a/src/markdown-pages/docs/getting-started.md
+++ b/src/markdown-pages/docs/getting-started.md
@@ -58,7 +58,7 @@ Then you will see a welcome message and the prompt `>` (If you cannot see the pr
 
 You can exit the CLI shell connection by pressing `ctrl+z`.
 
-You can use other serial terminal programs including `screen` command in macOS and Linux, or [PuTTY](https://www.putty.org/)) in Windows.
+You can use other serial terminal programs including `screen` command in macOS and Linux, or [PuTTY](https://www.putty.org/) in Windows.
 
 ## Setup project
 


### PR DESCRIPTION
Remove an orphan parentheses after the link to PuTTY in the Connect with Terminal section.

Before: You can use other serial terminal programs including screen command in macOS and Linux, or PuTTY) in Windows.

After: You can use other serial terminal programs including screen command in macOS and Linux, or PuTTY in Windows.